### PR TITLE
Add 3.6.2

### DIFF
--- a/travis-solr.sh
+++ b/travis-solr.sh
@@ -51,7 +51,7 @@ download_and_run() {
             dir_name="apache-solr-3.6.1"
             ;;
         3.6.2)
-            url="http://apache.rediris.es/lucene/solr/3.6.1/apache-solr-3.6.2.tgz"
+            url="http://apache.rediris.es/lucene/solr/3.6.2/apache-solr-3.6.2.tgz"
             dir_name="apache-solr-3.6.2"
             ;;
         4.0.0)


### PR DESCRIPTION
Since 3.6.1 doesn't appear to be in any Apache mirrors anymore 
(and is definitely not on apache.rediris.es).
