### PR TITLE
Update README to indicate quotes needed for SOLR_CONFS values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Usage
 
 ::
 
-  curl https://raw.github.com/moliware/travis-solr/master/travis-solr.sh | SOLR_VERSION=3.6.1 SOLR_CONFS=schema.xml solrconfig.xml SOLR_DOCS=custom_docs.json bash
+  curl https://raw.github.com/moliware/travis-solr/master/travis-solr.sh | SOLR_VERSION=3.6.1 SOLR_CONFS="schema.xml solrconfig.xml" SOLR_DOCS=custom_docs.json bash
 
 SOLR_VERSION:
 .............
@@ -36,6 +36,8 @@ SOLR_CONFS:
 
 If you need to use some custom configuration you can specify one or more files 
 in this variable and the script will copy it in the solr conf folder.
+
+Be sure to surround multiple values with quotes.
 
 Don't use it if you need the default solr settings.
 


### PR DESCRIPTION
The example for SOLR_CONFS needed to be updated with quotes so that bash did not try to execute the second config file.
