### PR TITLE
Update documentation - curl should be more robust on redirects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Usage
 
 ::
 
-  curl https://raw.githubusercontent.com/moliware/travis-solr/master/travis-solr.sh | SOLR_VERSION=3.6.1 SOLR_CONFS="schema.xml solrconfig.xml" SOLR_DOCS=custom_docs.json bash
+  curl -sSL https://raw.githubusercontent.com/moliware/travis-solr/master/travis-solr.sh | SOLR_VERSION=3.6.1 SOLR_CONFS="schema.xml solrconfig.xml" SOLR_DOCS=custom_docs.json bash
 
 SOLR_VERSION:
 .............
@@ -38,7 +38,7 @@ You have to specify one of these versions:
 SOLR_CONFS:
 ...........
 
-If you need to use some custom configuration you can specify one or more files 
+If you need to use some custom configuration you can specify one or more files
 in this variable and the script will copy it in the solr conf folder.
 
 Be sure to surround multiple values with quotes.
@@ -60,8 +60,8 @@ Solr will run on the default port 8983 if left blank.
 Travis-ci
 ---------
 
-Edit your .travis.yml and use travis-solr as a *before_script* script. 
+Edit your .travis.yml and use travis-solr as a *before_script* script.
 For example if you want to use solr 3.6.1 with the default settings you can add this
 line to your .travis.yml: ::
 
-  before_script: curl https://raw.githubusercontent.com/moliware/travis-solr/master/travis-solr.sh | SOLR_VERSION=3.6.1 bash
+  before_script: curl -sSL https://raw.githubusercontent.com/moliware/travis-solr/master/travis-solr.sh | SOLR_VERSION=3.6.1 bash


### PR DESCRIPTION
Hi,

curl should be configured to follow redirects and within builds it should also be as silent as possible. I'd therefore propose to update the documentation slightly.

The related changes / missing parameters cause problems which are quite hard to debug (see builds 28,29,30 in https://travis-ci.org/tolleiv/repoactivity/builds)

// In my commit (in the other repo) you also see that I'd submit the user-agent too - this solved problems for me in the past but didn't really help with solving the travis-solr issues. So I left it out in the pull-request.

Besides that - thanks for providing these great scripts.
Cheers, Tolleiv
