### PR TITLE
SOLR_CONFS can be multiple files.

### DIFF
--- a/travis-solr.sh
+++ b/travis-solr.sh
@@ -184,7 +184,7 @@ download_and_run() {
     esac
 
     download $url $dir_name
-    add_core $dir_name $dir_conf $SOLR_CORE $SOLR_CONFS
+    add_core $dir_name $dir_conf $SOLR_CORE "$SOLR_CONFS"
     run $dir_name $SOLR_PORT $SOLR_CORE
 
     if [ -z "${SOLR_DOCS}" ]


### PR DESCRIPTION
This is a small quoting fix to actually allow multiple files listed in `$SOLR_CONFS`.

Example:
```
SOLR_VERSION=3.6.2 SOLR_PORT=8080 SOLR_CONFS="schema.xml solrconfig.xml" bash
```