### PR TITLE
Improvements to multi-core support

### DIFF
--- a/travis-solr.sh
+++ b/travis-solr.sh
@@ -207,6 +207,7 @@ add_core() {
     # copies custom configurations
     if [ -d "${solr_confs}" ] ; then
       cp -R $solr_confs/* $dir_name/example/multicore/$solr_core/conf/
+      echo "Copied $solr_confs/* to solr conf directory."
     else
       for file in $solr_confs
       do
@@ -218,6 +219,10 @@ add_core() {
             exit 1
         fi
       done
+    fi
+    if [ "$solr_core" != "core0" -a "$solr_core" != "core1" ] ; then
+        echo "Adding $solr_core to solr.xml"
+        sed -i -e "s/<\/cores>/<core name=\"$solr_core\" instanceDir=\"$solr_core\" \/><\/cores>/" $dir_name/example/multicore/solr.xml
     fi
 }
 

--- a/travis-solr.sh
+++ b/travis-solr.sh
@@ -204,6 +204,9 @@ add_core() {
     [[ -d "${dir_name}/example/multicore/${solr_core}" ]] || mkdir $dir_name/example/multicore/$solr_core
     [[ -d "${dir_name}/example/multicore/${solr_core}/conf" ]] || mkdir $dir_name/example/multicore/$solr_core/conf
 
+    # copy text configs from default single core conf to new core to have proper defaults
+    cp -R $dir_name/example/solr/conf/{lang,*.txt} $dir_name/example/multicore/$solr_core/conf/
+
     # copies custom configurations
     if [ -d "${solr_confs}" ] ; then
       cp -R $solr_confs/* $dir_name/example/multicore/$solr_core/conf/
@@ -220,6 +223,8 @@ add_core() {
         fi
       done
     fi
+
+    # enable custom core
     if [ "$solr_core" != "core0" -a "$solr_core" != "core1" ] ; then
         echo "Adding $solr_core to solr.xml"
         sed -i -e "s/<\/cores>/<core name=\"$solr_core\" instanceDir=\"$solr_core\" \/><\/cores>/" $dir_name/example/multicore/solr.xml


### PR DESCRIPTION
Right now if you define a core that is not core0 or core1 it is actually never enabled and therefore not usable. The first commit makes sure that is fixed

The second commit ensures the language files like stopwords and such are copied from the base conf so they are available in the new core by default, but can be overwritten by the given config.