### PR TITLE
Use case wildcards to make script more flexible.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,41 +28,9 @@ Sorl 5.X schemaless example
 SOLR_VERSION:
 .............
 
-You have to specify one of these versions:
+You have to specify a valid version of Solr. See http://archive.apache.org/dist/lucene/solr/ for available releases.
 
-- 3.5.0
-- 3.6.0
-- 3.6.1
-- 3.6.2
-- 4.0.0
-- 4.1.0
-- 4.2.0
-- 4.2.1
-- 4.3.1
-- 4.4.0
-- 4.5.0
-- 4.5.1
-- 4.6.0
-- 4.6.1
-- 4.7.0
-- 4.7.1
-- 4.7.2
-- 4.8.0
-- 4.8.1
-- 4.9.0
-- 4.9.1
-- 4.10.0
-- 4.10.1
-- 4.10.2
-- 4.10.3
-- 4.10.4
-- 5.0.0
-- 5.1.0
-- 5.2.0
-- 5.2.1
-- 5.3.0
-- 5.3.1
-- 5.4.0
+*Note*: At this time Solr 6 is not supported.
 
 SOLR 3.X and 4.X variables
 ..........................

--- a/travis-solr.sh
+++ b/travis-solr.sh
@@ -70,25 +70,11 @@ run_solr5() {
 }
 
 download_and_run() {
+	version=$1
     case $1 in
-        3.5.0)
-            url="http://archive.apache.org/dist/lucene/solr/3.5.0/apache-solr-3.5.0.tgz"
-            dir_name="apache-solr-3.5.0"
-            dir_conf="conf/"
-            ;;
-        3.6.0)
-            url="http://archive.apache.org/dist/lucene/solr/3.6.0/apache-solr-3.6.0.tgz"
-            dir_name="apache-solr-3.6.0"
-            dir_conf="conf/"
-            ;;
-        3.6.1)
-            url="http://archive.apache.org/dist/lucene/solr/3.6.1/apache-solr-3.6.1.tgz"
-            dir_name="apache-solr-3.6.1"
-            dir_conf="conf/"
-            ;;
-        3.6.2)
-            url="http://archive.apache.org/dist/lucene/solr/3.6.2/apache-solr-3.6.2.tgz"
-            dir_name="apache-solr-3.6.2"
+        3.*)
+            url="http://archive.apache.org/dist/lucene/solr/${version}/apache-solr-${version}.tgz"
+            dir_name="apache-solr-${version}"
             dir_conf="conf/"
             ;;
         4.0.0)
@@ -96,139 +82,18 @@ download_and_run() {
             dir_name="apache-solr-4.0.0"
             dir_conf="collection1/conf/"
             ;;
-        4.1.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.1.0/solr-4.1.0.tgz"
-            dir_name="solr-4.1.0"
+        4.*)
+            url="http://archive.apache.org/dist/lucene/solr/${version}/solr-${version}.tgz"
+            dir_name="solr-${version}"
             dir_conf="collection1/conf/"
             ;;
-        4.2.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.2.0/solr-4.2.0.tgz"
-            dir_name="solr-4.2.0"
-            dir_conf="collection1/conf/"
+        5.*)
+            url="http://archive.apache.org/dist/lucene/solr/${version}/solr-${version}.tgz"
+            dir_name="solr-${version}"
             ;;
-        4.2.1)
-            url="http://archive.apache.org/dist/lucene/solr/4.2.1/solr-4.2.1.tgz"
-            dir_name="solr-4.2.1"
-            dir_conf="collection1/conf/"
-            ;;
-        4.3.1)
-            url="http://archive.apache.org/dist/lucene/solr/4.3.1/solr-4.3.1.tgz"
-            dir_name="solr-4.3.1"
-            dir_conf="collection1/conf/"
-            ;;
-        4.4.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.4.0/solr-4.4.0.tgz"
-            dir_name="solr-4.4.0"
-            dir_conf="collection1/conf/"
-            ;;
-        4.5.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.5.0/solr-4.5.0.tgz"
-            dir_name="solr-4.5.0"
-            dir_conf="collection1/conf/"
-            ;;
-        4.5.1)
-            url="http://archive.apache.org/dist/lucene/solr/4.5.1/solr-4.5.1.tgz"
-            dir_name="solr-4.5.1"
-            dir_conf="collection1/conf/"
-            ;;
-        4.6.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.6.0/solr-4.6.0.tgz"
-            dir_name="solr-4.6.0"
-            dir_conf="collection1/conf/"
-            ;;
-        4.6.1)
-            url="http://archive.apache.org/dist/lucene/solr/4.6.1/solr-4.6.1.tgz"
-            dir_name="solr-4.6.1"
-            dir_conf="collection1/conf/"
-            ;;
-        4.7.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.7.0/solr-4.7.0.tgz"
-            dir_name="solr-4.7.0"
-            dir_conf="collection1/conf/"
-            ;;
-        4.7.1)
-            url="http://archive.apache.org/dist/lucene/solr/4.7.1/solr-4.7.1.tgz"
-            dir_name="solr-4.7.1"
-            dir_conf="collection1/conf/"
-            ;;
-        4.7.2)
-            url="http://archive.apache.org/dist/lucene/solr/4.7.2/solr-4.7.2.tgz"
-            dir_name="solr-4.7.2"
-            dir_conf="collection1/conf/"
-            ;;
-        4.8.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.8.0/solr-4.8.0.tgz"
-            dir_name="solr-4.8.0"
-            dir_conf="collection1/conf/"
-            ;;
-        4.8.1)
-            url="http://archive.apache.org/dist/lucene/solr/4.8.1/solr-4.8.1.tgz"
-            dir_name="solr-4.8.1"
-            dir_conf="collection1/conf/"
-            ;;
-        4.9.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.9.0/solr-4.9.0.tgz"
-            dir_name="solr-4.9.0"
-            dir_conf="collection1/conf/"
-            ;;
-        4.9.1)
-            url="http://archive.apache.org/dist/lucene/solr/4.9.1/solr-4.9.1.tgz"
-            dir_name="solr-4.9.1"
-            dir_conf="collection1/conf/"
-            ;;
-        4.10.0)
-            url="http://archive.apache.org/dist/lucene/solr/4.10.0/solr-4.10.0.tgz"
-            dir_name="solr-4.10.0"
-            dir_conf="collection1/conf/"
-            ;;
-        4.10.1)
-            url="http://archive.apache.org/dist/lucene/solr/4.10.1/solr-4.10.1.tgz"
-            dir_name="solr-4.10.1"
-            dir_conf="collection1/conf/"
-            ;;
-        4.10.2)
-            url="http://archive.apache.org/dist/lucene/solr/4.10.2/solr-4.10.2.tgz"
-            dir_name="solr-4.10.2"
-            dir_conf="collection1/conf/"
-            ;;
-        4.10.3)
-            url="http://archive.apache.org/dist/lucene/solr/4.10.3/solr-4.10.3.tgz"
-            dir_name="solr-4.10.3"
-            dir_conf="collection1/conf/"
-            ;;
-        4.10.4)
-            url="http://archive.apache.org/dist/lucene/solr/4.10.4/solr-4.10.4.tgz"
-            dir_name="solr-4.10.4"
-            dir_conf="collection1/conf/"
-            ;;
-        5.0.0)
-            url="http://archive.apache.org/dist/lucene/solr/5.0.0/solr-5.0.0.tgz"
-            dir_name="solr-5.0.0"
-            ;;
-        5.1.0)
-            url="http://archive.apache.org/dist/lucene/solr/5.1.0/solr-5.1.0.tgz"
-            dir_name="solr-5.1.0"
-            ;;
-        5.2.0)
-            url="http://archive.apache.org/dist/lucene/solr/5.2.0/solr-5.2.0.tgz"
-            dir_name="solr-5.2.0"
-            ;;
-        5.2.1)
-            url="http://archive.apache.org/dist/lucene/solr/5.2.1/solr-5.2.1.tgz"
-            dir_name="solr-5.2.1"
-            ;;
-        5.3.0)
-            url="http://archive.apache.org/dist/lucene/solr/5.3.0/solr-5.3.0.tgz"
-            dir_name="solr-5.3.0"
-            ;;
-        5.3.1)
-            url="http://archive.apache.org/dist/lucene/solr/5.3.1/solr-5.3.1.tgz"
-            dir_name="solr-5.3.1"
-            ;;
-        5.4.0)
-            url="http://archive.apache.org/dist/lucene/solr/5.4.0/solr-5.4.0.tgz"
-            dir_name="solr-5.4.0"
-            ;;
+        *)
+			echo "Sorry, $1 is not supported or not valid version."
+			exit 1
     esac
 
     download $url $dir_name
@@ -335,15 +200,4 @@ post_documents_solr5() {
     fi
 }
 
-check_version() {
-    case $1 in
-        3.5.0|3.6.0|3.6.1|3.6.2|4.0.0|4.1.0|4.2.0|4.2.1|4.3.1|4.4.0|4.5.0|4.5.1|4.6.0|4.6.1|4.7.0|4.7.1|4.7.2|4.8.0|4.8.1|4.9.0|4.9.1|4.10.0|4.10.1|4.10.2|4.10.3|4.10.4|5.0.0|5.1.0|5.2.0|5.2.1|5.3.0|5.3.1|5.4.0);;
-        *)
-            echo "Sorry, $1 is not supported or not valid version."
-            exit 1
-            ;;
-    esac
-}
-
-check_version $SOLR_VERSION
 download_and_run $SOLR_VERSION


### PR DESCRIPTION
This avoids needing to add another case every time a point release
of Solr is published.