### PR TITLE
Support Solr 6

### DIFF
--- a/travis-solr.sh
+++ b/travis-solr.sh
@@ -87,7 +87,7 @@ download_and_run() {
             dir_name="solr-${version}"
             dir_conf="collection1/conf/"
             ;;
-        5.*)
+        5.*|6.*)
             url="http://archive.apache.org/dist/lucene/solr/${version}/solr-${version}.tgz"
             dir_name="solr-${version}"
             ;;
@@ -97,7 +97,7 @@ download_and_run() {
     esac
 
     download $url $dir_name
-    if [[ $1 == 5* ]]
+    if [[ $1 == 5* || $1 == 6* ]]
     then
         if [ -z "${SOLR_COLLECTION_CONF}" ]
         then


### PR DESCRIPTION
The toolchain is largely unchanged in Solr 6 so adding support is simple.